### PR TITLE
Add permissions to Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linting


### PR DESCRIPTION
# What

Adds content read permissions to test workflows

# Why

To fix:

* https://github.com/yamatt/homoglyphs/security/code-scanning/2
* https://github.com/yamatt/homoglyphs/security/code-scanning/1

And hopefully get the workflows picked up when being run