### PR TITLE
dependabot to update using uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# What

Switches Dependabot to scan for uv dependency updates

# Why

Dependabot now supports a specific uv package ecosystem which is faster, but also previously the pip updates seemed to have missed stuff.

# Notes

I expect there will be a lot of dependabot updates